### PR TITLE
Add full-stack scaffolding for Discord-like web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# MMlkatAlm3r8een
+# مملكة المعرقين
+
+مشروع ويب مبسط يعمل محليًا ويشبه Discord بخصائص محدودة.
+
+## التشغيل
+
+1. **Backend**
+   ```bash
+   cd backend
+   npm install
+   npm start
+   ```
+   يتطلب MongoDB محلي على المنفذ الافتراضي.
+
+2. **Frontend**
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+   ستعمل الواجهة على `http://localhost:3000`.
+
+يمكن مشاركة الموقع عبر عنوان Tailscale IP بعد تشغيل السيرفرين.

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+const connectDB = async () => {
+  try {
+    await mongoose.connect('mongodb://localhost:27017/mamlakat', {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    console.log('MongoDB connected');
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+};
+
+export default connectDB;

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,0 +1,17 @@
+import bcrypt from 'bcrypt';
+import User from '../models/User.js';
+
+export const login = async (req, res) => {
+  const { username, password } = req.body;
+  const user = await User.findOne({ username });
+  if (!user) return res.status(400).json({ message: 'User not found' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(400).json({ message: 'Wrong password' });
+  req.session.userId = user._id;
+  res.json({ message: 'Logged in', user });
+};
+
+export const logout = (req, res) => {
+  req.session.destroy();
+  res.json({ message: 'Logged out' });
+};

--- a/backend/controllers/channelController.js
+++ b/backend/controllers/channelController.js
@@ -1,0 +1,30 @@
+import VoiceChannel from '../models/VoiceChannel.js';
+import TextChannel from '../models/TextChannel.js';
+
+export const getChannels = async (req, res) => {
+  const voices = await VoiceChannel.find();
+  const texts = await TextChannel.find();
+  res.json({ voices, texts });
+};
+
+export const addVoice = async (req, res) => {
+  const channel = new VoiceChannel(req.body);
+  await channel.save();
+  res.json(channel);
+};
+
+export const addText = async (req, res) => {
+  const channel = new TextChannel(req.body);
+  await channel.save();
+  res.json(channel);
+};
+
+export const deleteVoice = async (req, res) => {
+  await VoiceChannel.findByIdAndDelete(req.params.id);
+  res.json({ message: 'Deleted' });
+};
+
+export const deleteText = async (req, res) => {
+  await TextChannel.findByIdAndDelete(req.params.id);
+  res.json({ message: 'Deleted' });
+};

--- a/backend/controllers/gameController.js
+++ b/backend/controllers/gameController.js
@@ -1,0 +1,12 @@
+import Game from '../models/Game.js';
+
+export const getGames = async (req, res) => {
+  const games = await Game.find();
+  res.json(games);
+};
+
+export const createGame = async (req, res) => {
+  const game = new Game(req.body);
+  await game.save();
+  res.json(game);
+};

--- a/backend/controllers/shortcutController.js
+++ b/backend/controllers/shortcutController.js
@@ -1,0 +1,17 @@
+import Shortcut from '../models/Shortcut.js';
+
+export const getShortcuts = async (req, res) => {
+  const shortcuts = await Shortcut.find();
+  res.json(shortcuts);
+};
+
+export const addShortcut = async (req, res) => {
+  const shortcut = new Shortcut(req.body);
+  await shortcut.save();
+  res.json(shortcut);
+};
+
+export const deleteShortcut = async (req, res) => {
+  await Shortcut.findByIdAndDelete(req.params.id);
+  res.json({ message: 'Deleted' });
+};

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,0 +1,33 @@
+import bcrypt from 'bcrypt';
+import User from '../models/User.js';
+
+export const getUsers = async (req, res) => {
+  const users = await User.find();
+  res.json(users);
+};
+
+export const addUser = async (req, res) => {
+  const { username, password, roles } = req.body;
+  const hash = await bcrypt.hash(password, 10);
+  const user = new User({ username, password: hash, roles, avatar: req.file?.filename });
+  await user.save();
+  res.json(user);
+};
+
+export const updateUser = async (req, res) => {
+  const { id } = req.params;
+  const { username, password, roles } = req.body;
+  const user = await User.findById(id);
+  if (!user) return res.status(404).json({ message: 'Not found' });
+  user.username = username || user.username;
+  if (password) user.password = await bcrypt.hash(password, 10);
+  if (roles) user.roles = roles;
+  if (req.file) user.avatar = req.file.filename;
+  await user.save();
+  res.json(user);
+};
+
+export const deleteUser = async (req, res) => {
+  await User.findByIdAndDelete(req.params.id);
+  res.json({ message: 'Deleted' });
+};

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,0 +1,4 @@
+export const requireLogin = (req, res, next) => {
+  if (!req.session.userId) return res.status(401).json({ message: 'Unauthorized' });
+  next();
+};

--- a/backend/models/Game.js
+++ b/backend/models/Game.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+const gameSchema = new mongoose.Schema({
+  name: String,
+  data: Object,
+});
+
+export default mongoose.model('Game', gameSchema);

--- a/backend/models/MemberPage.js
+++ b/backend/models/MemberPage.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const memberPageSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  bio: String,
+  images: [String],
+  videos: [String],
+});
+
+export default mongoose.model('MemberPage', memberPageSchema);

--- a/backend/models/Shortcut.js
+++ b/backend/models/Shortcut.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const shortcutSchema = new mongoose.Schema({
+  name: String,
+  url: String,
+  icon: String,
+});
+
+export default mongoose.model('Shortcut', shortcutSchema);

--- a/backend/models/TextChannel.js
+++ b/backend/models/TextChannel.js
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+const textChannelSchema = new mongoose.Schema({
+  name: String,
+  allowedRoles: [String],
+});
+
+export default mongoose.model('TextChannel', textChannelSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema({
+  username: { type: String, unique: true },
+  password: String,
+  roles: [String],
+  avatar: String,
+  about: String,
+});
+
+export default mongoose.model('User', userSchema);

--- a/backend/models/VoiceChannel.js
+++ b/backend/models/VoiceChannel.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const voiceChannelSchema = new mongoose.Schema({
+  name: String,
+  maxUsers: Number,
+  allowedRoles: [String],
+});
+
+export default mongoose.model('VoiceChannel', voiceChannelSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mamlakat-alm3r8een-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "mongoose": "^7.5.0",
+    "socket.io": "^4.7.2"
+  }
+}

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,7 @@
+import express from 'express';
+import { login, logout } from '../controllers/authController.js';
+
+const router = express.Router();
+router.post('/login', login);
+router.post('/logout', logout);
+export default router;

--- a/backend/routes/channels.js
+++ b/backend/routes/channels.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import { getChannels, addVoice, addText, deleteVoice, deleteText } from '../controllers/channelController.js';
+import { requireLogin } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.get('/', requireLogin, getChannels);
+router.post('/voice', requireLogin, addVoice);
+router.post('/text', requireLogin, addText);
+router.delete('/voice/:id', requireLogin, deleteVoice);
+router.delete('/text/:id', requireLogin, deleteText);
+
+export default router;

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getGames, createGame } from '../controllers/gameController.js';
+import { requireLogin } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.get('/', requireLogin, getGames);
+router.post('/', requireLogin, createGame);
+
+export default router;

--- a/backend/routes/shortcuts.js
+++ b/backend/routes/shortcuts.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { getShortcuts, addShortcut, deleteShortcut } from '../controllers/shortcutController.js';
+import { requireLogin } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+router.get('/', requireLogin, getShortcuts);
+router.post('/', requireLogin, addShortcut);
+router.delete('/:id', requireLogin, deleteShortcut);
+
+export default router;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import multer from 'multer';
+import { getUsers, addUser, updateUser, deleteUser } from '../controllers/userController.js';
+import { requireLogin } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+const upload = multer({ dest: 'backend/uploads/' });
+
+router.get('/', requireLogin, getUsers);
+router.post('/', requireLogin, upload.single('avatar'), addUser);
+router.put('/:id', requireLogin, upload.single('avatar'), updateUser);
+router.delete('/:id', requireLogin, deleteUser);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,47 @@
+import express from 'express';
+import session from 'express-session';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import { Server } from 'socket.io';
+import http from 'http';
+
+import connectDB from './config/db.js';
+import authRoutes from './routes/auth.js';
+import userRoutes from './routes/users.js';
+import channelRoutes from './routes/channels.js';
+import shortcutRoutes from './routes/shortcuts.js';
+import gameRoutes from './routes/games.js';
+
+connectDB();
+const app = express();
+const server = http.createServer(app);
+export const io = new Server(server, { cors: { origin: '*' } });
+
+app.use(cors());
+app.use(express.json());
+app.use('/uploads', express.static('backend/uploads'));
+app.use(
+  session({ secret: 'secretkey', resave: false, saveUninitialized: true })
+);
+
+io.on('connection', socket => {
+  socket.on('join-voice', ({ room }) => {
+    socket.join(room);
+    socket.to(room).emit('user-joined', socket.id);
+    socket.on('signal', data => {
+      socket.to(room).emit('signal', { id: socket.id, data });
+    });
+    socket.on('disconnect', () => {
+      socket.to(room).emit('user-left', socket.id);
+    });
+  });
+});
+
+app.use('/api/auth', authRoutes);
+app.use('/api/users', userRoutes);
+app.use('/api/channels', channelRoutes);
+app.use('/api/shortcuts', shortcutRoutes);
+app.use('/api/games', gameRoutes);
+
+const PORT = process.env.PORT || 5000;
+server.listen(PORT, () => console.log(`Server running on ${PORT}`));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>مملكة المعرقين</title>
+    <script type="module" src="/src/main.jsx"></script>
+  </head>
+  <body class="bg-gray-900 text-white">
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mamlakat-alm3r8een-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "socket.io-client": "^4.7.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.5.0",
+    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.16",
+    "autoprefixer": "^10.4.12"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import './index.css';
+
+function App() {
+  const user = JSON.parse(localStorage.getItem('user'));
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={user ? <Dashboard /> : <Navigate to="/login" />} />
+        <Route path="/login" element={<Login />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import io from 'socket.io-client';
+import UserManagement from './UserManagement.jsx';
+
+const socket = io('http://localhost:5000');
+
+export default function Dashboard() {
+  const [channels, setChannels] = useState({ voices: [], texts: [] });
+  const [currentRoom, setCurrentRoom] = useState(null);
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/api/channels').then(r => setChannels(r.data));
+  }, []);
+
+  const joinVoice = room => {
+    setCurrentRoom(room);
+    socket.emit('join-voice', { room });
+  };
+
+  return (
+    <div className="p-4 grid grid-cols-4 gap-4">
+      <div className="col-span-1">
+        <h1 className="text-2xl mb-4">مملكة المعرقين</h1>
+        <h2 className="text-xl mb-2">Voice Channels</h2>
+        <ul className="space-y-2">
+          {channels.voices.map(c => (
+            <li key={c._id}>
+              <button className="w-full bg-gray-700 p-2" onClick={() => joinVoice(c._id)}>{c.name}</button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="col-span-3 space-y-4">
+        {currentRoom ? <VoiceRoom room={currentRoom} /> : <p>Select voice room</p>}
+        <UserManagement />
+      </div>
+    </div>
+  );
+}
+
+function VoiceRoom({ room }) {
+  const [peers, setPeers] = useState([]);
+
+  useEffect(() => {
+    socket.emit('join-voice', { room });
+    socket.on('user-joined', id => setPeers(p => [...p, id]));
+    socket.on('user-left', id => setPeers(p => p.filter(x => x !== id)));
+    return () => {
+      socket.off('user-joined');
+      socket.off('user-left');
+    };
+  }, [room]);
+
+  return (
+    <div className="bg-gray-800 p-4">
+      <h2 className="text-xl">Room {room}</h2>
+      <p>Users: {peers.length + 1}</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const submit = async e => {
+    e.preventDefault();
+    const { data } = await axios.post('http://localhost:5000/api/auth/login', {
+      username,
+      password,
+    });
+    localStorage.setItem('user', JSON.stringify(data.user));
+    window.location.href = '/';
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <form onSubmit={submit} className="bg-gray-800 p-8 rounded grid gap-4">
+        <input className="p-2" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="p-2" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button className="bg-blue-600 p-2" type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/UserManagement.jsx
+++ b/frontend/src/pages/UserManagement.jsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+export default function UserManagement() {
+  const [users, setUsers] = useState([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [roles, setRoles] = useState('');
+
+  const fetchUsers = () =>
+    axios.get('http://localhost:5000/api/users').then(r => setUsers(r.data));
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const add = async e => {
+    e.preventDefault();
+    await axios.post('http://localhost:5000/api/users', { username, password, roles: roles.split(',') });
+    setUsername('');
+    setPassword('');
+    setRoles('');
+    fetchUsers();
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Users</h2>
+      <form onSubmit={add} className="mb-4 grid grid-cols-4 gap-2">
+        <input className="p-2" placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <input className="p-2" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <input className="p-2" placeholder="Roles comma separated" value={roles} onChange={e => setRoles(e.target.value)} />
+        <button className="bg-blue-600" type="submit">Add</button>
+      </form>
+      <ul>
+        {users.map(u => (
+          <li key={u._id}>{u.username} - {u.roles.join(', ')}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- initialize backend with Express, MongoDB, Socket.IO
- add models and controllers for users, channels, shortcuts, and games
- add REST API routes and simple auth middleware
- set up frontend with React + Vite + TailwindCSS
- implement login page, dashboard with voice room mock, and user management
- update README with run instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a28ccffd0833388395f86e6a81323